### PR TITLE
compress_video fixes and raise compression errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# video caches used for tests
+video_cache_py3.sqlite
+video_cache.sqlite
+.pytest_cache
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -9,6 +15,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
+venv2/
 build/
 develop-eggs/
 dist/

--- a/pressurecooker/videos.py
+++ b/pressurecooker/videos.py
@@ -77,8 +77,8 @@ def compress_video(source_file_path, target_file, overwrite=False, **kwargs):
     # run command
     command = ["ffmpeg", "-y" if overwrite else "-n", "-i", source_file_path, "-profile:v", "baseline",
                "-level", "3.0", "-b:a", "32k", "-ac", "1", "-vf", "scale={}".format(scale),
-               "-crf", str(crf), "-preset", "slow", "-strict", "-2", "-v", "quiet", "-stats", target_file]
+               "-crf", str(crf), "-preset", "slow", "-v", "error", "-strict", "-2", "-stats", target_file]
     try:
-        subprocess.check_call(command)
+        subprocess.check_output(command, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        raise VideoCompressionError(e)
+        raise VideoCompressionError("{}: {}".format(e, e.output))

--- a/pressurecooker/videos.py
+++ b/pressurecooker/videos.py
@@ -19,8 +19,10 @@ def guess_video_preset_by_resolution(videopath):
                                           'stream=width,height', '-of', 'default=noprint_wrappers=1', str(videopath)])
         pattern = re.compile('width=([0-9]*)[^height]+height=([0-9]*)')
         match = pattern.search(str(result))
+        if match is None:
+            return format_presets.VIDEO_LOW_RES
         width, height = int(match.group(1)), int(match.group(2))
-        if match and height >= 720:
+        if height >= 720:
             return format_presets.VIDEO_HIGH_RES
         else:
             return format_presets.VIDEO_LOW_RES

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+ffmpy>=0.2.2
+le-utils>=0.1.9
+matplotlib==2.0.0
+numpy==1.12.1
+Pillow>=3.3.1
+Wand==0.4.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,4 @@
-twine
+twine>=1.11.0
+requests==2.18.4
+requests-cache==0.4.13
+pytest>=3.5.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md') as readme_file:
 
 requirements = [
     "ffmpy>=0.2.2",
-    "le-utils>=0.0.9rc13",
+    "le-utils>=0.1.9",
     "matplotlib==2.0.0",
     "numpy==1.12.1",
     "Pillow>=3.3.1",

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -1,73 +1,81 @@
-import tempfile
-
+from __future__ import print_function
 import pytest
 import requests
 import requests_cache
+import sys
+import tempfile
+
 from le_utils.constants import format_presets
 
+# SUT
 from pressurecooker import videos
 
-# so we don't keep requesting the full videos
-requests_cache.install_cache("video_cache")
 
-JPG_MAGIC_NUMBER = '\xff\xd8'
-PNG_MAGIC_NUMBER = '\x89P'
+# cache, so we don't keep requesting the full videos
+if sys.version_info[0] == 3:
+    requests_cache.install_cache("video_cache_py3")
+else:
+    requests_cache.install_cache("video_cache")
+
+
 
 
 @pytest.fixture
 def low_res_video():
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(suffix='.mp4') as f:
         resp = requests.get(
             "https://archive.org/download/vd_is_for_everybody/vd_is_for_everybody_512kb.mp4",
             stream=True,
         )
-
-        for chunk in resp.iter_content():
+        for chunk in resp.iter_content(chunk_size=1048576):
             f.write(chunk)
-
+        f.flush()
         yield f
 
 
 @pytest.fixture
 def high_res_video():
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(suffix='.mp4') as f:
         resp = requests.get(
-            "https://archive.org/download/UnderConstructionFREEVideoBackgroundLoopHD1080p/cold%20night.mp4",
+            "https://ia800201.us.archive.org/7/items/"
+            "UnderConstructionFREEVideoBackgroundLoopHD1080p/"
+            "UnderConstruction%20-%20FREE%20Video%20Background%20Loop%20HD%201080p.mp4",
             stream=True
         )
-
-        for chunk in resp.iter_content():
+        for chunk in resp.iter_content(chunk_size=1048576):
             f.write(chunk)
-
+        f.flush()
         yield f
+
 
 
 class Test_check_video_resolution:
 
     def test_returns_a_format_preset(self, low_res_video):
-        preset = videos.check_video_resolution(low_res_video.name)
-
+        preset = videos.guess_video_preset_by_resolution(low_res_video.name)
         assert preset in [format_presets.VIDEO_HIGH_RES,
                           format_presets.VIDEO_LOW_RES,
                           format_presets.VIDEO_VECTOR]
 
     def test_detects_low_res_videos(self, low_res_video):
-        preset = videos.check_video_resolution(low_res_video.name)
-
+        preset = videos.guess_video_preset_by_resolution(low_res_video.name)
         assert preset == format_presets.VIDEO_LOW_RES
 
-    # figure out why the high_res_video is getting returned as low res
-    # def test_detects_high_res_videos(self, high_res_video):
-    #     preset = videos.check_video_resolution(high_res_video.name)
+    def test_detects_high_res_videos(self, high_res_video):
+        preset = videos.guess_video_preset_by_resolution(high_res_video.name)
+        assert preset == format_presets.VIDEO_HIGH_RES
 
-    #     assert preset == format_presets.VIDEO_HIGH_RES
 
+
+
+PNG_MAGIC_NUMBER = b'\x89P'
 
 class Test_extract_thumbnail_from_video:
 
     def test_returns_an_image(self, low_res_video):
-        with tempfile.NamedTemporaryFile(suffix=".jpg") as f:
-            videos.extract_thumbnail_from_video(low_res_video.name, f.name)
-            f.seek(0)
+        with tempfile.NamedTemporaryFile(suffix=".png") as pngf:
+            videos.extract_thumbnail_from_video(low_res_video.name, pngf.name, overwrite=True)
+            pngf.seek(0)
+            assert pngf.read(2) == PNG_MAGIC_NUMBER
 
-            assert f.read(2) == PNG_MAGIC_NUMBER
+

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -31,7 +31,7 @@ def low_res_video():
         for chunk in resp.iter_content(chunk_size=1048576):
             f.write(chunk)
         f.flush()
-    return f
+        return f
 
 
 @pytest.fixture
@@ -46,14 +46,14 @@ def high_res_video():
         for chunk in resp.iter_content(chunk_size=1048576):
             f.write(chunk)
         f.flush()
-    return f
+        return f
 
 @pytest.fixture
 def bad_video():
     with TempFile(suffix='.mp4') as f:
         f.write(b'novideohere. ffmpeg soshould error')
         f.flush()
-    return f
+        return f
 
 
 
@@ -82,11 +82,10 @@ class Test_extract_thumbnail_from_video:
 
     def test_returns_an_image(self, low_res_video):
         with TempFile(suffix=".png") as pngf:
-            pass
-        videos.extract_thumbnail_from_video(low_res_video.name, pngf.name, overwrite=True)
-        with open(pngf.name, "rb") as f:
-            f.seek(0)
-            assert f.read(2) == PNG_MAGIC_NUMBER
+            videos.extract_thumbnail_from_video(low_res_video.name, pngf.name, overwrite=True)
+            with open(pngf.name, "rb") as f:
+                f.seek(0)
+                assert f.read(2) == PNG_MAGIC_NUMBER
 
 
 
@@ -106,46 +105,41 @@ class Test_compress_video:
 
     def test_compression_works(self, high_res_video):
         with TempFile(suffix=".mp4") as vout:
-            pass
-        videos.compress_video(high_res_video.name, vout.name, overwrite=True)
-        width, height = get_resolution(vout.name)
-        assert height == 480, 'should compress to 480 v resolution by defualt'
+            videos.compress_video(high_res_video.name, vout.name, overwrite=True)
+            width, height = get_resolution(vout.name)
+            assert height == 480, 'should compress to 480 v resolution by defualt'
 
     def test_compression_max_width(self, high_res_video):
         with TempFile(suffix=".mp4") as vout:
-            pass
-        videos.compress_video(high_res_video.name, vout.name, overwrite=True, max_width=120)
-        width, height = get_resolution(vout.name)
-        assert width == 120, 'should be 120 h resolution since max_width set'
+            videos.compress_video(high_res_video.name, vout.name, overwrite=True, max_width=120)
+            width, height = get_resolution(vout.name)
+            assert width == 120, 'should be 120 h resolution since max_width set'
 
     def test_compression_max_width_odd(self, high_res_video):
         """
         regression test for: https://github.com/learningequality/pressurecooker/issues/11
         """
         with TempFile(suffix=".mp4") as vout:
-            pass
-        videos.compress_video(high_res_video.name, vout.name, overwrite=True, max_width=121)
-        width, height = get_resolution(vout.name)
-        assert width == 120, 'should round down to 120 h resolution when max_width=121 set'
+            videos.compress_video(high_res_video.name, vout.name, overwrite=True, max_width=121)
+            width, height = get_resolution(vout.name)
+            assert width == 120, 'should round down to 120 h resolution when max_width=121 set'
 
     def test_compression_max_height(self, high_res_video):
         with TempFile(suffix=".mp4") as vout:
-            pass
-        videos.compress_video(high_res_video.name, vout.name, overwrite=True, max_height=140)
-        width, height = get_resolution(vout.name)
-        assert height == 140, 'should be 140 v resolution since max_height set'
+            videos.compress_video(high_res_video.name, vout.name, overwrite=True, max_height=140)
+            width, height = get_resolution(vout.name)
+            assert height == 140, 'should be 140 v resolution since max_height set'
 
     def test_raises_for_bad_file(self, bad_video):
         with TempFile(suffix=".mp4") as vout:
-            pass
-        with pytest.raises(videos.VideoCompressionError):
-            videos.compress_video(bad_video.name, vout.name, overwrite=True)
+            with pytest.raises(videos.VideoCompressionError):
+                videos.compress_video(bad_video.name, vout.name, overwrite=True)
 
 
 
 ## Helper class for cross-platform temporary files
 
-def remove_file(*args, **kwargs):
+def remove_temp_file(*args, **kwargs):
     filename = args[0]
     try:
         os.remove(filename)
@@ -169,7 +163,7 @@ class TempFile(object):
     def __enter__(self):
         # create a temporary file as per usual, but set it up to be deleted once we're done
         self.f = tempfile.NamedTemporaryFile(*self.args, delete=False, **self.kwargs)
-        atexit.register(remove_file, self.f.name)
+        atexit.register(remove_temp_file, self.f.name)
         return self.f
 
     def __exit__(self, _type, value, traceback):

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -50,7 +50,7 @@ def high_res_video():
 
 
 @pytest.fixture
-def high_res_ogv_video():
+def low_res_ogv_video():
     with TempFile(suffix='.ogv') as f:
         resp = requests.get(
             "https://archive.org/download/"
@@ -175,9 +175,9 @@ class Test_convert_video:
             width, height = get_resolution(vout.name)
             assert height == 480, 'should convert .ogv to .mp4 and set 480 v res'
 
-    def test_convert_and_resize_ogv_works(self, high_res_ogv_video):
+    def test_convert_and_resize_ogv_works(self, low_res_ogv_video):
         with TempFile(suffix=".mp4") as vout:
-            videos.compress_video(high_res_ogv_video.name, vout.name, overwrite=True, max_height=200)
+            videos.compress_video(low_res_ogv_video.name, vout.name, overwrite=True, max_height=200)
             width, height = get_resolution(vout.name)
             assert height == 200, 'should convert .ogv to .mp4 and set 200 v res'
 

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -31,7 +31,7 @@ def low_res_video():
         for chunk in resp.iter_content(chunk_size=1048576):
             f.write(chunk)
         f.flush()
-        return f
+    return f               # returns a closed temporary (closed file descriptor)
 
 
 @pytest.fixture
@@ -46,14 +46,14 @@ def high_res_video():
         for chunk in resp.iter_content(chunk_size=1048576):
             f.write(chunk)
         f.flush()
-        return f
+    return f               # returns a closed temporary (closed file descriptor)
 
 @pytest.fixture
 def bad_video():
     with TempFile(suffix='.mp4') as f:
         f.write(b'novideohere. ffmpeg soshould error')
         f.flush()
-        return f
+    return f               # returns a closed temporary (closed file descriptor)
 
 
 


### PR DESCRIPTION
This PR makes `compress_video` scale logic more robust. Previously, it was possible to specify a invalid value of `max_width` (e.g. an odd value, or width value that produces an odd height if we keep the same aspect ratio).  (see https://github.com/learningequality/pressurecooker/issues/11)

Other stuff in here:
  - fixed tests
  - added requirements.py and and updated reqs in setup.py
  - added max_height kwarg option that works the same as max_width



## NEW NEW API change NEW NEW
Previously when ffmpeg call inside `compress_video` would fail, an empty file would be produced, which causes downsteam errors in content import (e.g. ricecooker erros our when tries to enerate thumbnail form an invalid video file). To avoid these "silent" errors, we `compress_video` will shoud loudly.... by raising an `VideoCompressionError`

Impact of this API change on Ricecooker:
  - `ricecooker` will be updated to skip file if `VideoCompressionError` and continue operation, but keep track in FAILED_FILES as usual

Impact of this API change on Studio:
  - `compress_video` is used in `compress_nodes` on Studio, but currently `compress_nodes` is not called anywhere, so no impact

Is pressurecooker used elsewhere?


## Testing instructions

The pressure cooker code base is used in both py2.7 (Studio) and py3.x (ricecooker) environments so it's important to test both. Something like

    virtualenv -p python2.7 venv2
    source venv/bin/activate   # or win equiv.
    pip install -r requirements.txt
    pip install -r requirements_dev.txt
    pytest

and

    virtualenv -p python3 venv3
    source venv/bin/activate   # or win equiv.
    pip install -r requirements.txt
    pip install -r requirements_dev.txt
    pytest