### PR TITLE
Only change the backend if it is the MacOSX native backend.

### DIFF
--- a/pressurecooker/images.py
+++ b/pressurecooker/images.py
@@ -11,7 +11,8 @@ import sys
 # automatically set the backend.
 if sys.platform.startswith("darwin"):
     import matplotlib
-    matplotlib.use('PS')
+    if matplotlib.get_backend().lower() == "macosx":
+        matplotlib.use('PS')
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure


### PR DESCRIPTION
If this fix doesn't work with Jupyter, we'll probably need to move the fix to the calling code (e.g. ricecooker and Studio)