### PR TITLE
fix for #20 = increase audio quality--bcs 32k is muffled

### DIFF
--- a/pressurecooker/videos.py
+++ b/pressurecooker/videos.py
@@ -76,7 +76,7 @@ def compress_video(source_file_path, target_file, overwrite=False, **kwargs):
 
     # run command
     command = ["ffmpeg", "-y" if overwrite else "-n", "-i", source_file_path, "-profile:v", "baseline",
-               "-level", "3.0", "-b:a", "32k", "-ac", "1", "-vf", "scale={}".format(scale),
+               "-level", "3.0", "-b:a", "64k", "-ac", "1", "-vf", "scale={}".format(scale),
                "-crf", str(crf), "-preset", "slow", "-v", "error", "-strict", "-2", "-stats", target_file]
     try:
         subprocess.check_output(command, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Fix for https://github.com/learningequality/pressurecooker/issues/20

Rationale: Audio stream contributes only small part of video; and good to have slightly better quality to hear teacher better.
