### PR TITLE
Test clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ ENV/
 
 # PyPI credential files (template is already committed)
 .pypirc
+
+# IntelliJ IDE (PyCharm)
+.idea/

--- a/pressurecooker/images.py
+++ b/pressurecooker/images.py
@@ -86,7 +86,7 @@ def create_waveform_image(fpath_in, fpath_out, max_num_of_points=None, colormap_
 
         #Extract Raw Audio from Wav File
         signal = spf.readframes(-1)
-        signal = np.fromstring(signal, 'Int16')
+        signal = np.frombuffer(signal, 'Int16')
 
         # Get subarray from middle
         length = len(signal)

--- a/pressurecooker/images.py
+++ b/pressurecooker/images.py
@@ -86,7 +86,7 @@ def create_waveform_image(fpath_in, fpath_out, max_num_of_points=None, colormap_
 
         #Extract Raw Audio from Wav File
         signal = spf.readframes(-1)
-        signal = np.frombuffer(signal, 'Int16')
+        signal = np.frombuffer(signal, np.int16)
 
         # Get subarray from middle
         length = len(signal)

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,13 @@ setenv =
 commands =
     pip install -U pip
     pip install -r requirements_dev.txt
-    pytest -s --basetemp={envtmpdir}
+    pytest --basetemp={envtmpdir}
 
 
 [testenv:flake8]
 basepython=python
 deps=flake8
 commands=flake8 pressurecooker
+
+[pytest]
+addopts = -s


### PR DESCRIPTION
## Description
I was running into issues running the tests. The changes hopefully make it more straightforward.

Eliminated some warnings generated from tests to clean up output:
```
tests/test_thumbnails.py::Test_wavefile_thumbnail_generation::test_generates_thumbnail
  /home/bjester/Projects/learningequality/pressurecooker/pressurecooker/images.py:89: DeprecationWarning: Numeric-style type codes are deprecated and will result in an error in the future.
    signal = np.frombuffer(signal, 'Int16')
```
and
```
tests/test_thumbnails.py::Test_wavefile_thumbnail_generation::test_generates_thumbnail
  /home/bjester/Projects/learningequality/pressurecooker/pressurecooker/images.py:89: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    signal = np.fromstring(signal, np.int16)
```

Additionally, the tests in `tests/test_youtube.py` were failing when run straight with `pytest`. The tox configuration runs them with `-s` switch, which is required for them to pass with straight `pytest`. I updated the `tox.ini` to add that option, resolving the issue.