### PR TITLE
Catch exceptions from pycaption

### DIFF
--- a/pressurecooker/subtitles.py
+++ b/pressurecooker/subtitles.py
@@ -1,6 +1,7 @@
 import codecs
 from pycaption import CaptionSet, WebVTTWriter
 from pycaption import WebVTTReader, SRTReader, SAMIReader, SCCReader, DFXPReader
+from pycaption  import CaptionReadError
 from pycaption.base import DEFAULT_LANGUAGE_CODE
 from le_utils.constants import file_formats
 
@@ -54,6 +55,9 @@ class SubtitleReader:
                 return self.reader.read(caption_str, lang=LANGUAGE_CODE_UNKNOWN)
 
             return self.reader.read(caption_str)
+        except CaptionReadError:
+            # added to suppress a CaptionReadNoCaptions error
+            return None
         except UnicodeDecodeError:
             return None
 


### PR DESCRIPTION
Had a very long chef crash out because of an uncaught exception.

Currently it's silently returning nothing, like the other exception.


Stacktrace:
```
  File "/data/py35/lib/python3.5/site-packages/pressurecooker/subtitles.py", line 88, in get_caption_set 
    self.caption_set = reader.read(self.caption_str) 
  File "/data/py35/lib/python3.5/site-packages/pressurecooker/subtitles.py", line 56, in read 
    return self.reader.read(caption_str) 
  File "/data/py35/lib/python3.5/site-packages/pycaption/dfxp/base.py", line 101, in read 
    raise CaptionReadNoCaptions(u"empty caption file") 
pycaption.exceptions.CaptionReadNoCaptions: CaptionReadNoCaptions(('empty caption file',)) 
```


