### PR TITLE
Handle pycaption errors

### DIFF
--- a/pressurecooker/subtitles.py
+++ b/pressurecooker/subtitles.py
@@ -1,6 +1,7 @@
 import codecs
 from pycaption import CaptionSet, WebVTTWriter
 from pycaption import WebVTTReader, SRTReader, SAMIReader, SCCReader, DFXPReader
+from pycaption  import CaptionReadError
 from pycaption.base import DEFAULT_LANGUAGE_CODE
 from le_utils.constants import file_formats
 
@@ -54,6 +55,9 @@ class SubtitleReader:
                 return self.reader.read(caption_str, lang=LANGUAGE_CODE_UNKNOWN)
 
             return self.reader.read(caption_str)
+        except CaptionReadError:
+            # added to suppress a CaptionReadNoCaptions error
+            return None
         except UnicodeDecodeError:
             return None
 

--- a/pressurecooker/subtitles.py
+++ b/pressurecooker/subtitles.py
@@ -1,7 +1,7 @@
 import codecs
 from pycaption import CaptionSet, WebVTTWriter
 from pycaption import WebVTTReader, SRTReader, SAMIReader, SCCReader, DFXPReader
-from pycaption  import CaptionReadError, CaptionReadNoCaptions
+from pycaption import CaptionReadError, CaptionReadNoCaptions
 from pycaption.base import DEFAULT_LANGUAGE_CODE
 from le_utils.constants import file_formats
 

--- a/tests/files/subtitles/empty.ttml
+++ b/tests/files/subtitles/empty.ttml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/2006/04/ttaf1" xmlns:tts="http://www.w3.org/2006/04/ttaf1#styling"
+      xml:lang="en">
+  <head>
+    <styling>
+      <style id="defaultSpeaker" tts:fontSize="12px" tts:fontFamily="SansSerif" tts:fontWeight="normal" tts:fontStyle="normal" tts:textDecoration="none" tts:color="white" tts:backgroundColor="black" tts:textAlign="left" />
+      <style id="defaultCaption" tts:fontSize="12px" tts:fontFamily="SansSerif" tts:fontWeight="normal" tts:fontStyle="normal" tts:textDecoration="none" tts:color="white" tts:backgroundColor="black" tts:textAlign="left" />
+    </styling>
+  </head>
+  <body id="thebody" style="defaultCaption">
+    <div xml:lang="en"/>
+  </body>
+</tt>

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -78,6 +78,14 @@ class SubtitleConverterTest(TestCase):
         with self.assertRaises(InvalidSubtitleFormatError):
             converter.convert(expected_language.code)
 
+    def test_invalid_format__empty(self):
+        expected_language = languages.getlang_by_name('English')
+
+        converter = build_subtitle_converter_from_file(os.path.join(test_files_dir, 'empty.ttml'))
+
+        with self.assertRaises(InvalidSubtitleFormatError, msg='Caption file is empty'):
+            converter.convert(expected_language.code)
+
     def test_valid_language(self):
         expected_file = os.path.join(test_files_dir, 'encapsulated.vtt')
         expected_language = languages.getlang_by_name('English')


### PR DESCRIPTION
The intention here is to catch some known errors thrown by pycaption. We consolidate them somewhat into `InvalidSubtitleFormatError` that can be more explicitly handled by implementations of this library, like in `ricecooker`.

Starting point: https://github.com/learningequality/pressurecooker/pull/42