### PR TITLE
Typo fix in proxy list manager and versions updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ python:
 before_install:
   - sudo apt-get -y -qq update
   - sudo apt-get install -y ffmpeg
-  - sudo apt-get install -y libmagickwand-dev
   - sudo apt-get install -y poppler-utils
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ A library of various media processing functions and utilities
 * [Install poppler-utils](https://poppler.freedesktop.org/) if you don't have it already
 
 
+## TODO for youtube v2
+ - cache json info
+ - To handle ExtractorError as permanent failure (do not try to download repeatedly)
+ - New "lightweight" playlist downloader based on `extract_flat`
+ - New get-all-subs for `youtube_id` helper that uses API (if token present) and youtube-dl as fallback
+
+
 ## Converting caption files
 The `pressurecooker` library contains utilities for converting caption files from a few various
 formats into the preferred `VTT` format. The currently supported formats include:
@@ -109,4 +116,6 @@ for lang_code in converter.get_language_codes():
     elif lang_code == LANGUAGE_CODE_UNKNOWN:
         raise InvalidSubtitleLanguageError('Unexpected unknown language')
 ```
+
+
 

--- a/pressurecooker/proxy.py
+++ b/pressurecooker/proxy.py
@@ -49,7 +49,7 @@ def load_broken_proxies_cache():
         return []
     mtime = os.path.getmtime(BROKEN_PROXIES_CACHE_FILENAME)
     if (time.time() - mtime) > 60*BROKEN_CACHE_EXPIRE_MINS:
-        os.path.remove(BROKEN_PROXIES_CACHE_FILENAME)
+        os.remove(BROKEN_PROXIES_CACHE_FILENAME)
         return []
     broken_proxies = []
     with open(BROKEN_PROXIES_CACHE_FILENAME, 'r') as bpl_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ le-utils>=0.1.24
 matplotlib==2.2.3
 numpy==1.15.4
 Pillow==5.4.1
-youtube-dl>=2020.1.24
+youtube-dl>=2020.3.24
 pdf2image==1.11.0
-le-pycaption>=2.1.0a2
+le-pycaption>=2.2.0a1
 EbookLib>=0.17.1

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,15 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "beautifulsoup4>=4.6.3",
     "ffmpy>=0.2.2",
     "le-utils>=0.1.24",
-    "matplotlib==2.2.3",    # the last with py27 support
-    "numpy==1.15.4",        # pinned to avoid surprizes
-    "Pillow==5.4.1",        # pinned to avoid surprizes
+    "matplotlib==2.2.3",            # the last with py27 support
+    "numpy==1.15.4",                # pinned to avoid surprizes (nothing specific)
+    "Pillow==5.4.1",                # pinned to avoid surprizes (nothing specific)
     "youtube-dl>=2020.3.24",
-    "pdf2image==1.11.0",    # pinned because py2.7 problems in 1.12.1
+    "pdf2image==1.11.0",            # pinned because py2.7 problems in 1.12.1
     "le-pycaption>=2.2.0a1",
+    "beautifulsoup4>=4.6.3,<4.9.0", # pinned to match versions in le-pycaption
     "EbookLib>=0.17.1",
 ]
 if sys.version_info < (3, 0, 0):

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ requirements = [
     "matplotlib==2.2.3",    # the last with py27 support
     "numpy==1.15.4",        # pinned to avoid surprizes
     "Pillow==5.4.1",        # pinned to avoid surprizes
-    "youtube-dl>=2020.1.24",
+    "youtube-dl>=2020.3.24",
     "pdf2image==1.11.0",    # pinned because py2.7 problems in 1.12.1
-    "le-pycaption>=2.1.0a2",
+    "le-pycaption>=2.2.0a1",
     "EbookLib>=0.17.1",
 ]
 if sys.version_info < (3, 0, 0):


### PR DESCRIPTION
In this PR:
 - small typo fix
 - use new le-pycaption 2.2.0 (py27 and py35+ support)
 - add beautifulsoup4 as an explicit dependency so we can pin the version that matchs le-pycaption version
